### PR TITLE
Fix: (import) Adiciona cover padrão para albuns sem cover

### DIFF
--- a/src/api/album/controllers/album.js
+++ b/src/api/album/controllers/album.js
@@ -40,9 +40,11 @@ module.exports = createCoreController("api::album.album", ({ strapi }) => ({
             } = album;
 
             try {
+              const imageUrl = typeof imageRendered === 'boolean' ? 'http://dummyimage.com/400.jpg' : imageRendered;
+
               const downloaded = await strapi
                 .service("api::album.download")
-                .download(imageRendered);
+                .download(imageUrl);
 
               const [{ id: fileId }] = await strapi
                 .service("api::album.upload")


### PR DESCRIPTION
Alguns albuns da API ![core.bandas1album](https://core.bandas1album.com.br/wp-json/wp/v2/album) não tem um cover definido. Quando isso acontece, o campo que viria a url **(string)**, vem com um valor booleano, causando um erro no service download do Strapi.

Essa alteração apenas verifica se o valor que veio da API no campo images é um booleano e seta uma imagem padrão para o cover do álbum.

Fix #1 